### PR TITLE
Added support for custom hls configuration

### DIFF
--- a/src/main/kotlin/boo/fox/haskelllsp/HaskellLanguageServerFactory.kt
+++ b/src/main/kotlin/boo/fox/haskelllsp/HaskellLanguageServerFactory.kt
@@ -1,14 +1,17 @@
 package boo.fox.haskelllsp
 
+import com.google.gson.JsonParser
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.EnvironmentUtil
 import com.redhat.devtools.lsp4ij.LanguageServerFactory
 import com.redhat.devtools.lsp4ij.LanguageServerManager
 import com.redhat.devtools.lsp4ij.server.ProcessStreamConnectionProvider
 import com.redhat.devtools.lsp4ij.server.StreamConnectionProvider
 import java.io.File
+import java.io.FileReader
 import java.nio.file.Paths
 import kotlin.io.path.pathString
 
@@ -34,5 +37,18 @@ class HaskellLanguageServer(project: Project) : ProcessStreamConnectionProvider(
                 ).notify(project)
             LanguageServerManager.getInstance(project).stop("haskellLanguageServer")
         }
+    }
+
+    override fun getInitializationOptions(rootUri: VirtualFile?): Any? {
+        if (rootUri !== null) {
+            val hlsConf = rootUri.findFileByRelativePath("hls.json")
+
+            if (hlsConf != null) {
+                val initializationOptions = JsonParser.parseReader(FileReader(hlsConf.path))
+                return initializationOptions
+            }
+        }
+
+        return null;
     }
 }

--- a/src/main/kotlin/boo/fox/haskelllsp/HaskellLanguageServerFactory.kt
+++ b/src/main/kotlin/boo/fox/haskelllsp/HaskellLanguageServerFactory.kt
@@ -43,7 +43,7 @@ class HaskellLanguageServer(project: Project) : ProcessStreamConnectionProvider(
         if (rootUri !== null) {
             val hlsConf = rootUri.findFileByRelativePath("hls.json")
 
-            if (hlsConf != null) {
+            if (hlsConf != null && hlsConf.exists()) {
                 val initializationOptions = JsonParser.parseReader(FileReader(hlsConf.path))
                 return initializationOptions
             }


### PR DESCRIPTION
With the most recent plugin version I got a lot of error message like this:

> No plugins are available to handle this SMethod_TextDocumentSemanticTokensFull request.
> Plugins installed for this method, but not available to handle this request are: semanticTokens is disabled globally in your config.

It seems the semantic tokens plugin is available but disabled by default: https://github.com/haskell/haskell-language-server/issues/4081#issuecomment-1949124141

This PR adds support for custom hls configuration. If a `hls.json` is found in the project root, then this file is used as initialization options.

This allows to enable the semantic tokens plugin with `"globalOn": true` as in:

```json
{
    ...
    "plugin": {
        ...
        "semanticTokens": {
            "config": {
                "classMethodToken": "method",
                "classToken": "class",
                "dataConstructorToken": "enumMember",
                "functionToken": "function",
                "moduleToken": "namespace",
                "operatorToken": "operator",
                "patternSynonymToken": "macro",
                "recordFieldToken": "property",
                "typeConstructorToken": "enum",
                "typeFamilyToken": "interface",
                "typeSynonymToken": "type",
                "typeVariableToken": "typeParameter",
                "variableToken": "variable"
            },
            "globalOn": true
        },
        ...
    }
}
```

For an example project see: https://github.com/dozed/test-hs

The proper way for this would probably be to create a plugin configuration interface, but this method here works for now.
