### PR TITLE
Update LSP4IJ to 0.5 + updates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,25 +1,28 @@
 plugins {
     id("java")
-    id("org.jetbrains.kotlin.jvm") version "1.9.22"
-    id("org.jetbrains.intellij") version "1.17.2"
+    id("org.jetbrains.kotlin.jvm") version "1.9.25"
+    id("org.jetbrains.intellij.platform") version "2.0.1"
     id("org.jetbrains.grammarkit") version "2022.3.2.2"
 }
 
 group = "boo.fox"
-version = "1.3.2"
+version = "1.3.3"
 
 repositories {
     mavenCentral()
+    intellijPlatform {
+        defaultRepositories()
+    }
 }
 
-// Configure Gradle IntelliJ Plugin
-// Read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
-intellij {
-    version.set("2023.3.6")
-    type.set("IC") // Target IDE Platform
-
-    plugins.set(listOf("com.redhat.devtools.lsp4ij:0.0.2"))
-    apply(plugin = "org.jetbrains.grammarkit")
+dependencies {
+    intellijPlatform {
+        intellijIdeaCommunity("2023.3.6")
+        plugin("com.redhat.devtools.lsp4ij:0.5.0")
+        pluginVerifier()
+        zipSigner()
+        instrumentationTools()
+    }
 }
 
 grammarKit {
@@ -49,9 +52,13 @@ tasks {
         dependsOn("generateHaskellParser")
     }
 
+    buildSearchableOptions {
+        enabled = false
+    }
+
     patchPluginXml {
         sinceBuild.set("232")
-        untilBuild.set("242.*")
+        untilBuild.set("243.*")
     }
 
     signPlugin {

--- a/src/main/kotlin/boo/fox/haskelllsp/HaskellLanguageServerFactory.kt
+++ b/src/main/kotlin/boo/fox/haskelllsp/HaskellLanguageServerFactory.kt
@@ -6,6 +6,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.util.EnvironmentUtil
 import com.redhat.devtools.lsp4ij.LanguageServerFactory
 import com.redhat.devtools.lsp4ij.LanguageServerManager
+import com.redhat.devtools.lsp4ij.ServerStatus
+import com.redhat.devtools.lsp4ij.client.LanguageClientImpl
 import com.redhat.devtools.lsp4ij.server.ProcessStreamConnectionProvider
 import com.redhat.devtools.lsp4ij.server.StreamConnectionProvider
 import java.io.File
@@ -14,15 +16,16 @@ import kotlin.io.path.pathString
 
 class HaskellLanguageServerFactory : LanguageServerFactory {
     override fun createConnectionProvider(project: Project): StreamConnectionProvider = HaskellLanguageServer(project)
+    override fun createLanguageClient(project: Project): LanguageClientImpl = HaskellLanguageClient(project)
 }
 
 class HaskellLanguageServer(project: Project) : ProcessStreamConnectionProvider() {
-    private fun findExecutableInPATH(executable: String) =
+    private fun findExecutableInPATH() =
         EnvironmentUtil.getEnvironmentMap().values.flatMap { it.split(File.pathSeparator) }
-            .map { File(Paths.get(it, executable).pathString) }.find { it.exists() && it.canExecute() }?.path
+            .map { File(Paths.get(it, HLS_EXECUTABLE_NAME).pathString) }.find { it.exists() && it.canExecute() }?.path
 
     init {
-        val hlsPath = findExecutableInPATH("haskell-language-server-wrapper")
+        val hlsPath = findExecutableInPATH()
         if (!hlsPath.isNullOrEmpty()) {
             super.setCommands(listOf(hlsPath, "--lsp"))
             super.setWorkingDirectory(project.basePath)
@@ -33,6 +36,22 @@ class HaskellLanguageServer(project: Project) : ProcessStreamConnectionProvider(
                     NotificationType.ERROR
                 ).notify(project)
             LanguageServerManager.getInstance(project).stop("haskellLanguageServer")
+        }
+    }
+
+    companion object {
+        const val HLS_EXECUTABLE_NAME: String = "haskell-language-server-wrapper"
+    }
+}
+
+// enabling the semanticTokens plugin is required for semantic tokens support
+class HaskellLanguageClient(project: Project): LanguageClientImpl(project) {
+    override fun createSettings(): Any? =
+        mapOf("haskell" to mapOf("plugin" to mapOf("semanticTokens" to mapOf("globalOn" to true))))
+
+    override fun handleServerStatusChanged(serverStatus: ServerStatus?) {
+        if (serverStatus == ServerStatus.started) {
+            triggerChangeConfiguration()
         }
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,6 +13,11 @@
     </description>
 
     <change-notes><![CDATA[
+    <h3>1.3.3</h3>
+    <ul>
+        <li>Update LSP4IJ to 0.5</li>
+        <li>Enable <code>semanticTokens</code> plugin</li>
+    </ul>
     <h3>1.3.2</h3>
     <ul>
         <li>More stable HLS location logic</li>


### PR DESCRIPTION
This PR does a bunch of things to keep the project up-to-date:

- Update LSP4IJ to 0.5
- As a result, we now have support for semantic tokens, so this is enabled in the Haskell LSP side too
- Update IntelliJ Platform Gradle plug-in to 2.0