### PR TITLE
Add native WSL2 support for launching HLS inside WSL

### DIFF
--- a/src/main/kotlin/boo/fox/haskelllsp/HaskellLanguageServerFactory.kt
+++ b/src/main/kotlin/boo/fox/haskelllsp/HaskellLanguageServerFactory.kt
@@ -1,5 +1,7 @@
 package boo.fox.haskelllsp
 
+import boo.fox.haskelllsp.wsl.WslHaskellLanguageServer
+import boo.fox.haskelllsp.wsl.WslSupport
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.project.Project
@@ -15,7 +17,15 @@ import java.io.File
 import java.nio.file.Paths
 
 class HaskellLanguageServerFactory : LanguageServerFactory {
-    override fun createConnectionProvider(project: Project): StreamConnectionProvider = HaskellLanguageServer(project)
+    override fun createConnectionProvider(project: Project): StreamConnectionProvider {
+        val wslInfo = WslSupport.detectWsl(project.basePath)
+        return if (wslInfo != null) {
+            WslHaskellLanguageServer(project, wslInfo)
+        } else {
+            HaskellLanguageServer(project)
+        }
+    }
+
     override fun createLanguageClient(project: Project): LanguageClientImpl = HaskellLanguageClient(project)
 }
 

--- a/src/main/kotlin/boo/fox/haskelllsp/wsl/WslHaskellLanguageServer.kt
+++ b/src/main/kotlin/boo/fox/haskelllsp/wsl/WslHaskellLanguageServer.kt
@@ -1,0 +1,205 @@
+package boo.fox.haskelllsp.wsl
+
+import boo.fox.haskelllsp.settings.HaskellLspSettings
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.project.Project
+import com.redhat.devtools.lsp4ij.server.ProcessStreamConnectionProvider
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+
+/**
+ * LSP connection provider that launches HLS inside a WSL2 distribution and transparently
+ * rewrites file URIs in both directions:
+ *
+ * - Outbound (IntelliJ → HLS): Windows UNC URIs like file:////wsl.localhost/Ubuntu/home/...
+ *   are converted to Linux URIs like file:///home/...
+ * - Inbound (HLS → IntelliJ): Linux URIs like file:///home/... are converted to Windows
+ *   UNC URIs like file:////wsl$/Ubuntu/home/...
+ */
+class WslHaskellLanguageServer(
+    project: Project,
+    private val wslInfo: WslSupport.WslPathInfo
+) : ProcessStreamConnectionProvider() {
+
+    private val distroName = wslInfo.distroName
+
+    // Outbound rewriting: strip WSL UNC prefix from URIs (IntelliJ → HLS)
+    // Handles 2-4 slashes after "file:" and all WSL UNC variants
+    private val outboundRegex = Regex(
+        """file:/{2,4}(?:wsl\.localhost|wsl\$|wsl%24)/$distroName/""",
+        RegexOption.IGNORE_CASE
+    )
+
+    // Inbound: rewrite local GHC doc/source URIs to Hackage URLs so they open in browser.
+    // Matches any file:/// URI ending in .html that contains /libraries/<package>/<path>.
+    // Uses [^/"]+ for package, [^")"] to stop at both " (JSON) and ) (markdown link end).
+    private val hackageRegex = Regex(
+        """file:///[^")*]*?/libraries/([^/"]+)/([^")]*?\.html(?:#[^")]*)?)"""
+    )
+
+    // Inbound rewriting: file:///home/... → file:////wsl$/Ubuntu/home/...
+    // Negative lookahead excludes Windows drive letters (file:///C:/...)
+    private val inboundRegex = Regex("""file:///(?![A-Za-z]:)""")
+    private val inboundReplacement = "file:////wsl\$/$distroName/"
+
+    private var inboundPipe: PipedInputStream? = null
+    private var outboundPipe: PipedOutputStream? = null
+    private var inboundRewriter: Thread? = null
+    private var outboundRewriter: Thread? = null
+
+    init {
+        val settings = HaskellLspSettings.getInstance()
+        val hlsCommand = settings.hlsPath.takeIf { it.isNotEmpty() }
+            ?: "haskell-language-server-wrapper"
+
+        // Use bash login shell so GHCup and other PATH modifications from
+        // .profile / .bash_profile are available. "exec" replaces bash with HLS
+        // to avoid any shell output corrupting the JSON-RPC stream.
+        super.setCommands(
+            listOf(
+                "wsl.exe", "-d", distroName,
+                "--cd", wslInfo.linuxPath,
+                "--", "bash", "-lc", "exec $hlsCommand --lsp"
+            )
+        )
+
+        NotificationGroupManager.getInstance().getNotificationGroup("Haskell LSP").createNotification(
+            "Haskell LSP",
+            "WSL detected ($distroName). Launching HLS inside WSL.",
+            NotificationType.INFORMATION
+        ).notify(project)
+    }
+
+    override fun start() {
+        super.start()
+        setupStreamRewriting()
+    }
+
+    private fun setupStreamRewriting() {
+        val rawIn = super.getInputStream() ?: return
+        val rawOut = super.getOutputStream() ?: return
+
+        // Inbound: HLS stdout → rewrite Linux URIs to Windows UNC → LSP4IJ reads
+        val inPipeOut = PipedOutputStream()
+        inboundPipe = PipedInputStream(inPipeOut, PIPE_BUFFER_SIZE)
+        inboundRewriter = createRewriterThread("WSL-LSP-Inbound", rawIn, inPipeOut, ::rewriteInbound)
+
+        // Outbound: LSP4IJ writes → rewrite Windows UNC URIs to Linux → HLS stdin
+        val outPipeIn = PipedInputStream(PIPE_BUFFER_SIZE)
+        outboundPipe = PipedOutputStream(outPipeIn)
+        outboundRewriter = createRewriterThread("WSL-LSP-Outbound", outPipeIn, rawOut, ::rewriteOutbound)
+
+        inboundRewriter!!.start()
+        outboundRewriter!!.start()
+    }
+
+    override fun getInputStream(): InputStream? = inboundPipe ?: super.getInputStream()
+    override fun getOutputStream(): OutputStream? = outboundPipe ?: super.getOutputStream()
+
+    override fun stop() {
+        inboundRewriter?.interrupt()
+        outboundRewriter?.interrupt()
+        runCatching { inboundPipe?.close() }
+        runCatching { outboundPipe?.close() }
+        super.stop()
+    }
+
+    private fun rewriteInbound(message: String): String {
+        // First: rewrite local GHC doc URIs to Hackage URLs (before generic file:/// rewriting)
+        val withHackage = hackageRegex.replace(message) { match ->
+            val packageVersion = match.groupValues[1]
+            val relativePath = match.groupValues[2]
+            "https://hackage.haskell.org/package/$packageVersion/docs/$relativePath"
+        }
+        // Then: rewrite remaining Linux file:/// URIs to Windows WSL UNC URIs
+        return inboundRegex.replace(withHackage) { inboundReplacement }
+    }
+
+    private fun rewriteOutbound(message: String): String {
+        return outboundRegex.replace(message, "file:///")
+    }
+
+    companion object {
+        private const val PIPE_BUFFER_SIZE = 262144 // 256 KB
+
+        private fun createRewriterThread(
+            name: String,
+            input: InputStream,
+            output: OutputStream,
+            rewrite: (String) -> String
+        ): Thread {
+            return Thread({
+                try {
+                    rewriteLoop(input, output, rewrite)
+                } catch (_: InterruptedException) {
+                } catch (_: java.io.IOException) {
+                }
+            }, name).apply { isDaemon = true }
+        }
+
+        /**
+         * Reads JSON-RPC framed messages from [input], applies [rewrite] to each message body,
+         * and writes the rewritten message (with updated Content-Length) to [output].
+         */
+        private fun rewriteLoop(input: InputStream, output: OutputStream, rewrite: (String) -> String) {
+            while (!Thread.currentThread().isInterrupted) {
+                // Read headers until empty line
+                var contentLength = -1
+                while (true) {
+                    val line = readLine(input) ?: return
+                    if (line.isEmpty()) break
+                    if (line.startsWith("Content-Length:", ignoreCase = true)) {
+                        contentLength = line.substringAfter(":").trim().toIntOrNull() ?: -1
+                    }
+                }
+
+                if (contentLength < 0) continue
+
+                // Read exactly contentLength bytes
+                val bodyBytes = ByteArray(contentLength)
+                var read = 0
+                while (read < contentLength) {
+                    val n = input.read(bodyBytes, read, contentLength - read)
+                    if (n == -1) return
+                    read += n
+                }
+
+                // Rewrite URIs in the message body
+                val body = String(bodyBytes, Charsets.UTF_8)
+                val rewritten = rewrite(body)
+                val rewrittenBytes = rewritten.toByteArray(Charsets.UTF_8)
+
+                // Write reframed message
+                synchronized(output) {
+                    output.write("Content-Length: ${rewrittenBytes.size}\r\n\r\n".toByteArray(Charsets.UTF_8))
+                    output.write(rewrittenBytes)
+                    output.flush()
+                }
+            }
+        }
+
+        /**
+         * Reads a single line terminated by \r\n from the input stream.
+         * Returns null on EOF.
+         */
+        private fun readLine(input: InputStream): String? {
+            val sb = StringBuilder()
+            while (true) {
+                val b = input.read()
+                if (b == -1) return null
+                if (b == '\r'.code) {
+                    val next = input.read()
+                    if (next == '\n'.code) return sb.toString()
+                    sb.append('\r')
+                    if (next == -1) return null
+                    sb.append(next.toChar())
+                } else {
+                    sb.append(b.toChar())
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/boo/fox/haskelllsp/wsl/WslHaskellLanguageServer.kt
+++ b/src/main/kotlin/boo/fox/haskelllsp/wsl/WslHaskellLanguageServer.kt
@@ -43,7 +43,7 @@ class WslHaskellLanguageServer(
     // Inbound rewriting: file:///home/... → file:////wsl$/Ubuntu/home/...
     // Negative lookahead excludes Windows drive letters (file:///C:/...)
     private val inboundRegex = Regex("""file:///(?![A-Za-z]:)""")
-    private val inboundReplacement = "file:////wsl\$/$distroName/"
+    private val inboundReplacement = "file:////wsl.localhost/$distroName/"
 
     private var inboundPipe: PipedInputStream? = null
     private var outboundPipe: PipedOutputStream? = null

--- a/src/main/kotlin/boo/fox/haskelllsp/wsl/WslHaskellLanguageServer.kt
+++ b/src/main/kotlin/boo/fox/haskelllsp/wsl/WslHaskellLanguageServer.kt
@@ -3,6 +3,7 @@ package boo.fox.haskelllsp.wsl
 import boo.fox.haskelllsp.settings.HaskellLspSettings
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
+import com.intellij.openapi.diagnostic.logger
 import com.intellij.openapi.project.Project
 import com.redhat.devtools.lsp4ij.server.ProcessStreamConnectionProvider
 import java.io.InputStream
@@ -17,7 +18,7 @@ import java.io.PipedOutputStream
  * - Outbound (IntelliJ → HLS): Windows UNC URIs like file:////wsl.localhost/Ubuntu/home/...
  *   are converted to Linux URIs like file:///home/...
  * - Inbound (HLS → IntelliJ): Linux URIs like file:///home/... are converted to Windows
- *   UNC URIs like file:////wsl$/Ubuntu/home/...
+ *   UNC URIs like file:////wsl.localhost/Ubuntu/home/...
  */
 class WslHaskellLanguageServer(
     project: Project,
@@ -29,7 +30,7 @@ class WslHaskellLanguageServer(
     // Outbound rewriting: strip WSL UNC prefix from URIs (IntelliJ → HLS)
     // Handles 2-4 slashes after "file:" and all WSL UNC variants
     private val outboundRegex = Regex(
-        """file:/{2,4}(?:wsl\.localhost|wsl\$|wsl%24)/$distroName/""",
+        """file:/{2,4}(?:wsl\.localhost|wsl\$|wsl%24)/${Regex.escape(distroName)}/""",
         RegexOption.IGNORE_CASE
     )
 
@@ -40,7 +41,7 @@ class WslHaskellLanguageServer(
         """file:///[^")*]*?/libraries/([^/"]+)/([^")]*?\.html(?:#[^")]*)?)"""
     )
 
-    // Inbound rewriting: file:///home/... → file:////wsl$/Ubuntu/home/...
+    // Inbound rewriting: file:///home/... → file:////wsl.localhost/Ubuntu/home/...
     // Negative lookahead excludes Windows drive letters (file:///C:/...)
     private val inboundRegex = Regex("""file:///(?![A-Za-z]:)""")
     private val inboundReplacement = "file:////wsl.localhost/$distroName/"
@@ -49,11 +50,11 @@ class WslHaskellLanguageServer(
     private var outboundPipe: PipedOutputStream? = null
     private var inboundRewriter: Thread? = null
     private var outboundRewriter: Thread? = null
+    private val launchCommand: String
 
     init {
         val settings = HaskellLspSettings.getInstance()
-        val hlsCommand = settings.hlsPath.takeIf { it.isNotEmpty() }
-            ?: "haskell-language-server-wrapper"
+        launchCommand = buildLaunchCommand(settings.hlsPath, distroName)
 
         // Use bash login shell so GHCup and other PATH modifications from
         // .profile / .bash_profile are available. "exec" replaces bash with HLS
@@ -62,7 +63,7 @@ class WslHaskellLanguageServer(
             listOf(
                 "wsl.exe", "-d", distroName,
                 "--cd", wslInfo.linuxPath,
-                "--", "bash", "-lc", "exec $hlsCommand --lsp"
+                "--", "bash", "-lc", launchCommand
             )
         )
 
@@ -85,15 +86,17 @@ class WslHaskellLanguageServer(
         // Inbound: HLS stdout → rewrite Linux URIs to Windows UNC → LSP4IJ reads
         val inPipeOut = PipedOutputStream()
         inboundPipe = PipedInputStream(inPipeOut, PIPE_BUFFER_SIZE)
-        inboundRewriter = createRewriterThread("WSL-LSP-Inbound", rawIn, inPipeOut, ::rewriteInbound)
+        val inbound = createRewriterThread("WSL-LSP-Inbound", rawIn, inPipeOut, ::rewriteInbound)
+        inboundRewriter = inbound
 
         // Outbound: LSP4IJ writes → rewrite Windows UNC URIs to Linux → HLS stdin
         val outPipeIn = PipedInputStream(PIPE_BUFFER_SIZE)
         outboundPipe = PipedOutputStream(outPipeIn)
-        outboundRewriter = createRewriterThread("WSL-LSP-Outbound", outPipeIn, rawOut, ::rewriteOutbound)
+        val outbound = createRewriterThread("WSL-LSP-Outbound", outPipeIn, rawOut, ::rewriteOutbound)
+        outboundRewriter = outbound
 
-        inboundRewriter!!.start()
-        outboundRewriter!!.start()
+        inbound.start()
+        outbound.start()
     }
 
     override fun getInputStream(): InputStream? = inboundPipe ?: super.getInputStream()
@@ -124,6 +127,31 @@ class WslHaskellLanguageServer(
 
     companion object {
         private const val PIPE_BUFFER_SIZE = 262144 // 256 KB
+        private const val DEFAULT_WSL_HLS_COMMAND = "haskell-language-server-wrapper"
+
+        internal fun buildLaunchCommand(configuredPath: String?, distroName: String): String {
+            val executable = resolveWslExecutable(configuredPath, distroName)
+            return "exec ${shellQuote(executable)} --lsp"
+        }
+
+        internal fun resolveWslExecutable(configuredPath: String?, distroName: String): String {
+            val trimmedPath = configuredPath?.trim().orEmpty()
+            if (trimmedPath.isEmpty()) return DEFAULT_WSL_HLS_COMMAND
+
+            val uncPath = WslSupport.parseWslUncPath(trimmedPath)
+            if (uncPath != null && uncPath.first.equals(distroName, ignoreCase = true)) {
+                return uncPath.second
+            }
+
+            if (trimmedPath.startsWith("/")) return trimmedPath
+
+            // Windows host paths are not executable inside WSL; fall back to the distro PATH.
+            return DEFAULT_WSL_HLS_COMMAND
+        }
+
+        internal fun shellQuote(value: String): String = "'${value.replace("'", "'\"'\"'")}'"
+
+        private val LOG = logger<WslHaskellLanguageServer>()
 
         private fun createRewriterThread(
             name: String,
@@ -156,7 +184,10 @@ class WslHaskellLanguageServer(
                     }
                 }
 
-                if (contentLength < 0) continue
+                if (contentLength < 0) {
+                    LOG.warn("WSL LSP rewriter: received message with missing or invalid Content-Length; closing stream")
+                    return
+                }
 
                 // Read exactly contentLength bytes
                 val bodyBytes = ByteArray(contentLength)

--- a/src/main/kotlin/boo/fox/haskelllsp/wsl/WslSupport.kt
+++ b/src/main/kotlin/boo/fox/haskelllsp/wsl/WslSupport.kt
@@ -42,4 +42,14 @@ object WslSupport {
 
         return WslPathInfo(distroName, linuxPath, distribution)
     }
+
+    internal fun parseWslUncPath(path: String?): Pair<String, String>? {
+        if (path == null) return null
+
+        val match = WSL_UNC_PREFIX.matchEntire(path) ?: return null
+        val distroName = match.groupValues[1]
+        val remainder = match.groupValues[2]
+        val linuxPath = if (remainder.isEmpty()) "/" else remainder.replace('\\', '/')
+        return distroName to linuxPath
+    }
 }

--- a/src/main/kotlin/boo/fox/haskelllsp/wsl/WslSupport.kt
+++ b/src/main/kotlin/boo/fox/haskelllsp/wsl/WslSupport.kt
@@ -1,0 +1,45 @@
+package boo.fox.haskelllsp.wsl
+
+import com.intellij.execution.wsl.WSLDistribution
+import com.intellij.execution.wsl.WslDistributionManager
+import com.intellij.openapi.util.SystemInfo
+
+object WslSupport {
+    // Matches both backslash (\\wsl.localhost\Ubuntu\...) and forward-slash
+    // (//wsl.localhost/Ubuntu/...) variants — IntelliJ's project.basePath may use either.
+    private val WSL_UNC_PREFIX = Regex(
+        """^(?:\\\\|//)(?:wsl\$|wsl\.localhost)[/\\]([^/\\]+)(.*)$""",
+        RegexOption.IGNORE_CASE
+    )
+
+    data class WslPathInfo(
+        val distroName: String,
+        val linuxPath: String,
+        val distribution: WSLDistribution
+    )
+
+    /**
+     * Detects if the given path is a WSL UNC path (e.g. \\wsl.localhost\Ubuntu\home\...
+     * or //wsl.localhost/Ubuntu/home/...) and returns parsed information including the
+     * resolved WSL distribution.
+     * Returns null if the path is not a WSL path, WSL is not available, or the distribution is not installed.
+     */
+    fun detectWsl(windowsPath: String?): WslPathInfo? {
+        if (!SystemInfo.isWindows || windowsPath == null) return null
+
+        val match = WSL_UNC_PREFIX.matchEntire(windowsPath) ?: return null
+        val distroName = match.groupValues[1]
+        val remainder = match.groupValues[2]
+        val linuxPath = if (remainder.isEmpty()) "/" else remainder.replace('\\', '/')
+
+        val distribution = try {
+            WslDistributionManager.getInstance().installedDistributions.find {
+                it.msId.equals(distroName, ignoreCase = true)
+            }
+        } catch (_: Exception) {
+            null
+        } ?: return null
+
+        return WslPathInfo(distroName, linuxPath, distribution)
+    }
+}

--- a/src/test/kotlin/boo/fox/haskelllsp/wsl/WslLaunchCommandTest.kt
+++ b/src/test/kotlin/boo/fox/haskelllsp/wsl/WslLaunchCommandTest.kt
@@ -1,0 +1,55 @@
+package boo.fox.haskelllsp.wsl
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WslLaunchCommandTest {
+
+    @Test
+    fun `uses default wrapper when no custom path is configured`() {
+        assertEquals(
+            "exec 'haskell-language-server-wrapper' --lsp",
+            WslHaskellLanguageServer.buildLaunchCommand("", "Ubuntu")
+        )
+    }
+
+    @Test
+    fun `keeps linux custom path and shell quotes it`() {
+        assertEquals(
+            "exec '/home/user/bin/haskell language server' --lsp",
+            WslHaskellLanguageServer.buildLaunchCommand("/home/user/bin/haskell language server", "Ubuntu")
+        )
+    }
+
+    @Test
+    fun `converts matching wsl unc path to linux path`() {
+        assertEquals(
+            "/home/user/.local/bin/hls",
+            WslHaskellLanguageServer.resolveWslExecutable("""\\wsl.localhost\Ubuntu\home\user\.local\bin\hls""", "Ubuntu")
+        )
+    }
+
+    @Test
+    fun `falls back to wrapper for windows host path`() {
+        assertEquals(
+            "haskell-language-server-wrapper",
+            WslHaskellLanguageServer.resolveWslExecutable("""C:\Users\user\AppData\Local\Programs\hls.exe""", "Ubuntu")
+        )
+    }
+
+    @Test
+    fun `returns linux absolute path unchanged`() {
+        assertEquals(
+            "/home/user/.ghcup/bin/haskell-language-server",
+            WslHaskellLanguageServer.resolveWslExecutable("/home/user/.ghcup/bin/haskell-language-server", "Ubuntu")
+        )
+    }
+
+    @Test
+    fun `shell quotes single quotes safely`() {
+        assertEquals(
+            "exec '/home/user/it'\"'\"'s hls' --lsp",
+            WslHaskellLanguageServer.buildLaunchCommand("/home/user/it's hls", "Ubuntu")
+        )
+    }
+}

--- a/src/test/kotlin/boo/fox/haskelllsp/wsl/WslUriRewritingTest.kt
+++ b/src/test/kotlin/boo/fox/haskelllsp/wsl/WslUriRewritingTest.kt
@@ -50,7 +50,7 @@ class WslUriRewritingTest {
     // Outbound: IntelliJ (Windows) → HLS (Linux)
     // file://{2,4}wsl.localhost/Ubuntu/... → file:///...
     private val outboundRegex = Regex(
-        """file:/{2,4}(?:wsl\.localhost|wsl\$|wsl%24)/$distroName/""",
+        """file:/{2,4}(?:wsl\.localhost|wsl\$|wsl%24)/${Regex.escape(distroName)}/""",
         RegexOption.IGNORE_CASE
     )
 

--- a/src/test/kotlin/boo/fox/haskelllsp/wsl/WslUriRewritingTest.kt
+++ b/src/test/kotlin/boo/fox/haskelllsp/wsl/WslUriRewritingTest.kt
@@ -34,9 +34,9 @@ class WslUriRewritingTest {
     )
 
     // Inbound: HLS (Linux) → IntelliJ (Windows)
-    // file:///home/... → file:////wsl$/Ubuntu/home/...
+    // file:///home/... → file:////wsl.localhost/Ubuntu/home/...
     private val inboundRegex = Regex("""file:///(?![A-Za-z]:)""")
-    private val inboundReplacement = "file:////wsl\$/$distroName/"
+    private val inboundReplacement = "file:////wsl.localhost/$distroName/"
 
     private fun rewriteInbound(message: String): String {
         val withHackage = hackageRegex.replace(message) { match ->
@@ -62,14 +62,14 @@ class WslUriRewritingTest {
     @Test
     fun `inbound rewrites Linux file URI to WSL UNC URI`() {
         val input = """{"uri":"file:///home/vojko/project/src/Main.hs"}"""
-        val expected = """{"uri":"file:////wsl$/Ubuntu/home/vojko/project/src/Main.hs"}"""
+        val expected = """{"uri":"file:////wsl.localhost/Ubuntu/home/vojko/project/src/Main.hs"}"""
         assertEquals(expected, rewriteInbound(input))
     }
 
     @Test
     fun `inbound rewrites multiple URIs in same message`() {
         val input = """{"uri":"file:///home/vojko/a.hs","target":"file:///home/vojko/b.hs"}"""
-        val expected = """{"uri":"file:////wsl$/Ubuntu/home/vojko/a.hs","target":"file:////wsl$/Ubuntu/home/vojko/b.hs"}"""
+        val expected = """{"uri":"file:////wsl.localhost/Ubuntu/home/vojko/a.hs","target":"file:////wsl.localhost/Ubuntu/home/vojko/b.hs"}"""
         assertEquals(expected, rewriteInbound(input))
     }
 
@@ -82,7 +82,7 @@ class WslUriRewritingTest {
     @Test
     fun `inbound handles usr local paths`() {
         val input = """{"uri":"file:///usr/local/lib/ghc/doc/index.html"}"""
-        val expected = """{"uri":"file:////wsl$/Ubuntu/usr/local/lib/ghc/doc/index.html"}"""
+        val expected = """{"uri":"file:////wsl.localhost/Ubuntu/usr/local/lib/ghc/doc/index.html"}"""
         assertEquals(expected, rewriteInbound(input))
     }
 
@@ -133,7 +133,7 @@ class WslUriRewritingTest {
     @Test
     fun `inbound does not rewrite non-library file URIs to Hackage`() {
         val input = """{"uri":"file:///home/vojko/project/src/Main.hs"}"""
-        val expected = """{"uri":"file:////wsl$/Ubuntu/home/vojko/project/src/Main.hs"}"""
+        val expected = """{"uri":"file:////wsl.localhost/Ubuntu/home/vojko/project/src/Main.hs"}"""
         assertEquals(expected, rewriteInbound(input))
     }
 
@@ -198,7 +198,7 @@ class WslUriRewritingTest {
 
     @Test
     fun `round trip outbound then inbound preserves original WSL URI`() {
-        val original = """{"uri":"file:////wsl$/Ubuntu/home/vojko/project/Main.hs"}"""
+        val original = """{"uri":"file:////wsl.localhost/Ubuntu/home/vojko/project/Main.hs"}"""
         val afterOutbound = rewriteOutbound(original)
         assertEquals("""{"uri":"file:///home/vojko/project/Main.hs"}""", afterOutbound)
         val afterInbound = rewriteInbound(afterOutbound)

--- a/src/test/kotlin/boo/fox/haskelllsp/wsl/WslUriRewritingTest.kt
+++ b/src/test/kotlin/boo/fox/haskelllsp/wsl/WslUriRewritingTest.kt
@@ -1,0 +1,251 @@
+package boo.fox.haskelllsp.wsl
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Tests for the URI rewriting logic used by WslHaskellLanguageServer,
+ * and the WSL path detection regex used by WslSupport.
+ * These tests exercise the patterns directly without requiring a running WSL instance.
+ */
+class WslUriRewritingTest {
+
+    private val distroName = "Ubuntu"
+
+    // Same regex as WslSupport.WSL_UNC_PREFIX
+    private val wslPathRegex = Regex(
+        """^(?:\\\\|//)(?:wsl\$|wsl\.localhost)[/\\]([^/\\]+)(.*)$""",
+        RegexOption.IGNORE_CASE
+    )
+
+    private fun parseWslPath(path: String): Pair<String, String>? {
+        val match = wslPathRegex.matchEntire(path) ?: return null
+        val distro = match.groupValues[1]
+        val remainder = match.groupValues[2]
+        val linuxPath = if (remainder.isEmpty()) "/" else remainder.replace('\\', '/')
+        return distro to linuxPath
+    }
+
+    // Hackage rewriting: local GHC doc URIs → Hackage URLs
+    private val hackageRegex = Regex(
+        """file:///[^")*]*?/libraries/([^/"]+)/([^")]*?\.html(?:#[^")]*)?)"""
+    )
+
+    // Inbound: HLS (Linux) → IntelliJ (Windows)
+    // file:///home/... → file:////wsl$/Ubuntu/home/...
+    private val inboundRegex = Regex("""file:///(?![A-Za-z]:)""")
+    private val inboundReplacement = "file:////wsl\$/$distroName/"
+
+    private fun rewriteInbound(message: String): String {
+        val withHackage = hackageRegex.replace(message) { match ->
+            val packageVersion = match.groupValues[1]
+            val relativePath = match.groupValues[2]
+            "https://hackage.haskell.org/package/$packageVersion/docs/$relativePath"
+        }
+        return inboundRegex.replace(withHackage) { inboundReplacement }
+    }
+
+    // Outbound: IntelliJ (Windows) → HLS (Linux)
+    // file://{2,4}wsl.localhost/Ubuntu/... → file:///...
+    private val outboundRegex = Regex(
+        """file:/{2,4}(?:wsl\.localhost|wsl\$|wsl%24)/$distroName/""",
+        RegexOption.IGNORE_CASE
+    )
+
+    private fun rewriteOutbound(message: String): String =
+        outboundRegex.replace(message, "file:///")
+
+    // --- Inbound tests (HLS → IntelliJ) ---
+
+    @Test
+    fun `inbound rewrites Linux file URI to WSL UNC URI`() {
+        val input = """{"uri":"file:///home/vojko/project/src/Main.hs"}"""
+        val expected = """{"uri":"file:////wsl$/Ubuntu/home/vojko/project/src/Main.hs"}"""
+        assertEquals(expected, rewriteInbound(input))
+    }
+
+    @Test
+    fun `inbound rewrites multiple URIs in same message`() {
+        val input = """{"uri":"file:///home/vojko/a.hs","target":"file:///home/vojko/b.hs"}"""
+        val expected = """{"uri":"file:////wsl$/Ubuntu/home/vojko/a.hs","target":"file:////wsl$/Ubuntu/home/vojko/b.hs"}"""
+        assertEquals(expected, rewriteInbound(input))
+    }
+
+    @Test
+    fun `inbound does not rewrite Windows drive letter URIs`() {
+        val input = """{"uri":"file:///C:/Users/vojko/project/Main.hs"}"""
+        assertEquals(input, rewriteInbound(input))
+    }
+
+    @Test
+    fun `inbound handles usr local paths`() {
+        val input = """{"uri":"file:///usr/local/lib/ghc/doc/index.html"}"""
+        val expected = """{"uri":"file:////wsl$/Ubuntu/usr/local/lib/ghc/doc/index.html"}"""
+        assertEquals(expected, rewriteInbound(input))
+    }
+
+    @Test
+    fun `inbound preserves non-file URIs`() {
+        val input = """{"uri":"https://hackage.haskell.org/package/base"}"""
+        assertEquals(input, rewriteInbound(input))
+    }
+
+    // --- Hackage doc rewriting tests (inbound) ---
+
+    @Test
+    fun `inbound rewrites GHC doc URI to Hackage URL`() {
+        val input = """{"uri":"file:///home/vojko/.ghcup/share/doc/ghc-9.8.4/html/libraries/base-4.19.2.0/Data-List.html"}"""
+        val expected = """{"uri":"https://hackage.haskell.org/package/base-4.19.2.0/docs/Data-List.html"}"""
+        assertEquals(expected, rewriteInbound(input))
+    }
+
+    @Test
+    fun `inbound rewrites GHC doc URI with anchor`() {
+        val input = """{"uri":"file:///home/vojko/.ghcup/share/doc/ghc-9.8.4/html/libraries/base-4.19.2.0/Data-List.html#v:sort"}"""
+        val expected = """{"uri":"https://hackage.haskell.org/package/base-4.19.2.0/docs/Data-List.html#v:sort"}"""
+        assertEquals(expected, rewriteInbound(input))
+    }
+
+    @Test
+    fun `inbound rewrites GHC source doc URI to Hackage`() {
+        val input = """{"uri":"file:///home/vojko/.ghcup/share/doc/ghc-9.8.4/html/libraries/base-4.19.2.0/src/Data.List.html"}"""
+        val expected = """{"uri":"https://hackage.haskell.org/package/base-4.19.2.0/docs/src/Data.List.html"}"""
+        assertEquals(expected, rewriteInbound(input))
+    }
+
+    @Test
+    fun `inbound rewrites different package doc URIs`() {
+        val input = """{"uri":"file:///usr/lib/ghc/doc/libraries/containers-0.6.7/Data-Map.html"}"""
+        val expected = """{"uri":"https://hackage.haskell.org/package/containers-0.6.7/docs/Data-Map.html"}"""
+        assertEquals(expected, rewriteInbound(input))
+    }
+
+    @Test
+    fun `inbound rewrites both doc and source links in markdown hover`() {
+        // This is the actual format HLS sends: markdown with doc + source links in one JSON string
+        val input = """{"value":"[Documentation](file:///home/vojko/.ghcup/ghc/9.6.7/share/doc/ghc-9.6.7/html/libraries/ghc-prim-0.10.0/GHC-Types.html#t:IO)\n\n[Source](file:///home/vojko/.ghcup/ghc/9.6.7/share/doc/ghc-9.6.7/html/libraries/ghc-prim-0.10.0/src/GHC.Types.html#IO)\n\n\n"}"""
+        val expected = """{"value":"[Documentation](https://hackage.haskell.org/package/ghc-prim-0.10.0/docs/GHC-Types.html#t:IO)\n\n[Source](https://hackage.haskell.org/package/ghc-prim-0.10.0/docs/src/GHC.Types.html#IO)\n\n\n"}"""
+        assertEquals(expected, rewriteInbound(input))
+    }
+
+    @Test
+    fun `inbound does not rewrite non-library file URIs to Hackage`() {
+        val input = """{"uri":"file:///home/vojko/project/src/Main.hs"}"""
+        val expected = """{"uri":"file:////wsl$/Ubuntu/home/vojko/project/src/Main.hs"}"""
+        assertEquals(expected, rewriteInbound(input))
+    }
+
+    // --- Outbound tests (IntelliJ → HLS) ---
+
+    @Test
+    fun `outbound rewrites wsl_localhost UNC URI to Linux URI`() {
+        val input = """{"rootUri":"file:////wsl.localhost/Ubuntu/home/vojko/project"}"""
+        val expected = """{"rootUri":"file:///home/vojko/project"}"""
+        assertEquals(expected, rewriteOutbound(input))
+    }
+
+    @Test
+    fun `outbound rewrites wsl_dollar UNC URI to Linux URI`() {
+        val input = """{"rootUri":"file:////wsl$/Ubuntu/home/vojko/project"}"""
+        val expected = """{"rootUri":"file:///home/vojko/project"}"""
+        assertEquals(expected, rewriteOutbound(input))
+    }
+
+    @Test
+    fun `outbound rewrites url-encoded wsl dollar URI`() {
+        val input = """{"rootUri":"file:////wsl%24/Ubuntu/home/vojko/project"}"""
+        val expected = """{"rootUri":"file:///home/vojko/project"}"""
+        assertEquals(expected, rewriteOutbound(input))
+    }
+
+    @Test
+    fun `outbound is case-insensitive for distro name in wsl_localhost`() {
+        val input = """{"rootUri":"file:////wsl.localhost/ubuntu/home/vojko/project"}"""
+        val expected = """{"rootUri":"file:///home/vojko/project"}"""
+        assertEquals(expected, rewriteOutbound(input))
+    }
+
+    @Test
+    fun `outbound rewrites 3-slash wsl_localhost URI`() {
+        val input = """{"rootUri":"file:///wsl.localhost/Ubuntu/home/vojko/project"}"""
+        val expected = """{"rootUri":"file:///home/vojko/project"}"""
+        assertEquals(expected, rewriteOutbound(input))
+    }
+
+    @Test
+    fun `outbound rewrites 2-slash wsl_localhost URI`() {
+        val input = """{"rootUri":"file://wsl.localhost/Ubuntu/home/vojko/project"}"""
+        val expected = """{"rootUri":"file:///home/vojko/project"}"""
+        assertEquals(expected, rewriteOutbound(input))
+    }
+
+    @Test
+    fun `outbound preserves plain Linux URIs`() {
+        val input = """{"uri":"file:///home/vojko/project/Main.hs"}"""
+        assertEquals(input, rewriteOutbound(input))
+    }
+
+    @Test
+    fun `outbound rewrites multiple URIs in workspace folders`() {
+        val input = """{"workspaceFolders":[{"uri":"file:////wsl.localhost/Ubuntu/home/vojko/a"},{"uri":"file:////wsl.localhost/Ubuntu/home/vojko/b"}]}"""
+        val expected = """{"workspaceFolders":[{"uri":"file:///home/vojko/a"},{"uri":"file:///home/vojko/b"}]}"""
+        assertEquals(expected, rewriteOutbound(input))
+    }
+
+    // --- Round-trip tests ---
+
+    @Test
+    fun `round trip outbound then inbound preserves original WSL URI`() {
+        val original = """{"uri":"file:////wsl$/Ubuntu/home/vojko/project/Main.hs"}"""
+        val afterOutbound = rewriteOutbound(original)
+        assertEquals("""{"uri":"file:///home/vojko/project/Main.hs"}""", afterOutbound)
+        val afterInbound = rewriteInbound(afterOutbound)
+        assertEquals(original, afterInbound)
+    }
+
+    // --- WSL path detection tests ---
+
+    @Test
+    fun `detects backslash wsl_localhost path`() {
+        val result = parseWslPath("""\\wsl.localhost\Ubuntu\home\vojko\project""")
+        assertNotNull(result)
+        assertEquals("Ubuntu", result.first)
+        assertEquals("/home/vojko/project", result.second)
+    }
+
+    @Test
+    fun `detects forward-slash wsl_localhost path`() {
+        val result = parseWslPath("//wsl.localhost/Ubuntu/home/vojko/project")
+        assertNotNull(result)
+        assertEquals("Ubuntu", result.first)
+        assertEquals("/home/vojko/project", result.second)
+    }
+
+    @Test
+    fun `detects backslash wsl_dollar path`() {
+        val result = parseWslPath("""\\wsl$\Ubuntu\home\vojko""")
+        assertNotNull(result)
+        assertEquals("Ubuntu", result.first)
+        assertEquals("/home/vojko", result.second)
+    }
+
+    @Test
+    fun `detects forward-slash wsl_dollar path`() {
+        val result = parseWslPath("//wsl\$/Ubuntu/home/vojko")
+        assertNotNull(result)
+        assertEquals("Ubuntu", result.first)
+        assertEquals("/home/vojko", result.second)
+    }
+
+    @Test
+    fun `returns null for regular Windows path`() {
+        assertNull(parseWslPath("""C:\Users\vojko\project"""))
+    }
+
+    @Test
+    fun `returns null for regular Linux path`() {
+        assertNull(parseWslPath("/home/vojko/project"))
+    }
+}


### PR DESCRIPTION
When a project is opened from a WSL path (\wsl.localhost\<distro>\...), the plugin now automatically:

- Detects the WSL distribution from the project path
- Launches HLS inside WSL via bash login shell (for GHCup PATH)
- Rewrites file URIs in both directions between Windows UNC and Linux paths
- Rewrites local GHC documentation/source HTML links to Hackage URLs

**Disclaimer**: The code is completely authored by: Claude Opus 4.6 (1M context)